### PR TITLE
Fix sync issues when audio and video are played simultaneously

### DIFF
--- a/src/videomeg_browser/audio_browser.py
+++ b/src/videomeg_browser/audio_browser.py
@@ -517,6 +517,11 @@ class AudioBrowser(SyncableMediaBrowser):
         """Get the current position in seconds."""
         return self._audio_view.current_time
 
+    @property
+    def is_playing(self) -> bool:
+        """Return whether the audio is currently playing."""
+        return self._is_playing
+
     def set_position(
         self, position_idx: int, media_idx: int, signal: bool = True
     ) -> bool:

--- a/src/videomeg_browser/audio_browser.py
+++ b/src/videomeg_browser/audio_browser.py
@@ -437,6 +437,9 @@ class AudioBrowser(SyncableMediaBrowser):
         By default 50 ms, which corresponds to 20 updates per second.
     parent : QWidget | None, optional
         The parent widget, by default None.
+
+    NOTE: This browser currently only supports a single audio file. Methods that receive
+    `media_idx` parameter ignore it and signals emit `media_idx` as zero.
     """
 
     def __init__(
@@ -578,7 +581,7 @@ class AudioBrowser(SyncableMediaBrowser):
         self._playback_timer.start()
         self._is_playing = True
 
-        self.sigPlaybackStateChanged.emit(0, True)
+        self.sigPlaybackStateChanged.emit(0, True)  # emit zero as media_idx
 
     def pause_playback(self) -> None:
         """Pause the audio playback."""
@@ -588,7 +591,7 @@ class AudioBrowser(SyncableMediaBrowser):
         self._playback_timer.stop()
         self._is_playing = False
 
-        self.sigPlaybackStateChanged.emit(0, False)
+        self.sigPlaybackStateChanged.emit(0, False)  # emit zero as media_idx
 
     def _update_browser_to_current_sample(self) -> None:
         """Update the audio browser UI to reflect the currently selected sample."""

--- a/src/videomeg_browser/syncable_media_browser.py
+++ b/src/videomeg_browser/syncable_media_browser.py
@@ -36,6 +36,8 @@ class SyncableMediaBrowser(QWidget):
             raise TypeError(f"{cls.__name__} must implement start_playback method.")
         if cls.pause_playback is SyncableMediaBrowser.pause_playback:
             raise TypeError(f"{cls.__name__} must implement pause_playback method.")
+        if cls.is_playing is SyncableMediaBrowser.is_playing:
+            raise TypeError(f"{cls.__name__} must implement is_playing property.")
 
     def set_position(
         self, position_idx: int, media_idx: int, signal: bool = True
@@ -119,4 +121,11 @@ class SyncableMediaBrowser(QWidget):
         """Pause playback of the currently playing media."""
         raise NotImplementedError(
             "pause_playback method must be implemented by subclasses."
+        )
+
+    @property
+    def is_playing(self) -> bool:
+        """Return whether the media is currently playing."""
+        raise NotImplementedError(
+            "is_playing property must be implemented by subclasses."
         )

--- a/src/videomeg_browser/syncable_media_browser.py
+++ b/src/videomeg_browser/syncable_media_browser.py
@@ -18,6 +18,10 @@ class SyncableMediaBrowser(QWidget):
     """Base class for syncable video and audio browser widgets.
 
     Defines methods and signal that subclasses must implement.
+
+    NOTE: This class does not inherit from abc.ABC to prevent metaclass conflicts
+    with Qt widgets. Instead, it uses `__init_subclass__` to enforce
+    implementation of required methods in subclasses.
     """
 
     # Emits a signal when the displayed frame or sample of any shown media changes.

--- a/src/videomeg_browser/syncable_media_browser.py
+++ b/src/videomeg_browser/syncable_media_browser.py
@@ -22,6 +22,7 @@ class SyncableMediaBrowser(QWidget):
 
     # Emits a signal when the displayed frame or sample of any shown media changes.
     sigPositionChanged = Signal(int, int)  # media index, sample index
+    sigPlaybackStateChanged = Signal(int, bool)  # media index, is playing
 
     def __init_subclass__(cls) -> None:
         """Ensure that subclasses implement required methods."""
@@ -31,6 +32,10 @@ class SyncableMediaBrowser(QWidget):
             raise TypeError(f"{cls.__name__} must implement jump_to_end method.")
         if cls.jump_to_start is SyncableMediaBrowser.jump_to_start:
             raise TypeError(f"{cls.__name__} must implement jump_to_start method.")
+        if cls.start_playback is SyncableMediaBrowser.start_playback:
+            raise TypeError(f"{cls.__name__} must implement start_playback method.")
+        if cls.pause_playback is SyncableMediaBrowser.pause_playback:
+            raise TypeError(f"{cls.__name__} must implement pause_playback method.")
 
     def set_position(
         self, position_idx: int, media_idx: int, signal: bool = True
@@ -97,3 +102,21 @@ class SyncableMediaBrowser(QWidget):
         """
         # Default implementation does nothing.
         pass
+
+    def start_playback(self, media_idx: int) -> None:
+        """Start playing the specified media.
+
+        Parameters
+        ----------
+        media_idx : int
+            Index of the media to start playing.
+        """
+        raise NotImplementedError(
+            "start_playback method must be implemented by subclasses."
+        )
+
+    def pause_playback(self) -> None:
+        """Pause playback of the currently playing media."""
+        raise NotImplementedError(
+            "pause_playback method must be implemented by subclasses."
+        )

--- a/src/videomeg_browser/synced_raw_media_browser.py
+++ b/src/videomeg_browser/synced_raw_media_browser.py
@@ -291,18 +291,14 @@ class SyncedRawMediaBrowser(QObject):
             f"for media browser {media_browser_idx} to {is_playing}."
         )
         if is_playing:
-            logger.debug(
-                "Pausing all other media browsers except the one on index "
-                f"{media_browser_idx}."
-            )
             self._pause_other_media_browsers(media_browser_idx)
 
     def _pause_other_media_browsers(self, excluded_browser_idx: int) -> None:
         """Pause all other media browsers except the one with the given index."""
         for browser_idx, media_browser in enumerate(self._media_browsers):
-            if excluded_browser_idx == browser_idx:
-                continue
-            media_browser.pause_playback()
+            if excluded_browser_idx != browser_idx and media_browser.is_playing:
+                logger.debug(f"Pausing media browser with index {browser_idx}.")
+                media_browser.pause_playback()
 
 
 class BufferedThrottler(QObject):

--- a/src/videomeg_browser/synced_raw_media_browser.py
+++ b/src/videomeg_browser/synced_raw_media_browser.py
@@ -122,6 +122,13 @@ class SyncedRawMediaBrowser(QObject):
             self._sync_media_to_raw  # no throttling needed here
         )
 
+        # When one browser starts playing, pause all other media browsers
+        # to avoid mess in synchronization.
+        for browser_idx, media_browser in enumerate(self._media_browsers):
+            media_browser.sigPlaybackStateChanged.connect(
+                functools.partial(self._on_playback_state_changed, browser_idx)
+            )
+
         # Consider raw data browser to be the main browser and start by
         # synchronizing the media browsers to the initial raw time.
         initial_raw_time = self._raw_browser_manager.get_selected_time()
@@ -273,6 +280,29 @@ class SyncedRawMediaBrowser(QObject):
 
             case _:
                 raise ValueError(f"Unexpected mapping result: {mapping}. ")
+
+    @Slot(int, int, bool)
+    def _on_playback_state_changed(
+        self, media_browser_idx: int, media_idx: int, is_playing: bool
+    ) -> None:
+        """Prevent other media browsers from playing when one starts playing."""
+        logger.debug(
+            "Received signal about playback state change "
+            f"for media browser {media_browser_idx} to {is_playing}."
+        )
+        if is_playing:
+            logger.debug(
+                "Pausing all other media browsers except the one on index "
+                f"{media_browser_idx}."
+            )
+            self._pause_other_media_browsers(media_browser_idx)
+
+    def _pause_other_media_browsers(self, excluded_browser_idx: int) -> None:
+        """Pause all other media browsers except the one with the given index."""
+        for browser_idx, media_browser in enumerate(self._media_browsers):
+            if excluded_browser_idx == browser_idx:
+                continue
+            media_browser.pause_playback()
 
 
 class BufferedThrottler(QObject):

--- a/src/videomeg_browser/video_browser.py
+++ b/src/videomeg_browser/video_browser.py
@@ -159,6 +159,11 @@ class VideoBrowser(SyncableMediaBrowser):
 
         self._update_buttons_enabled()
 
+    @property
+    def is_playing(self) -> bool:
+        """Return whether the video is currently playing."""
+        return self._is_playing
+
     @Slot(int)
     def display_frame_for_selected_video(self, frame_idx: int) -> bool:
         """Display the frame at the specified index for the selected video view.

--- a/src/videomeg_browser/video_browser.py
+++ b/src/videomeg_browser/video_browser.py
@@ -138,7 +138,7 @@ class VideoBrowser(SyncableMediaBrowser):
         self._navigation_bar.sigNextClicked.connect(
             self.display_next_frame_for_selected_video
         )
-        self._navigation_bar.sigPlayPauseClicked.connect(self.toggle_play_pause)
+        self._navigation_bar.sigPlayPauseClicked.connect(self._toggle_play_pause)
         navigation_layout.addWidget(self._navigation_bar)
 
         # Add drop-down menu for selecting which video to control.
@@ -271,8 +271,21 @@ class VideoBrowser(SyncableMediaBrowser):
             self._get_current_frame_index_of_selected_video() - 1
         )
 
+    # Overrides the empty implementation of parent class
+    def set_sync_status(self, status: SyncStatus, media_idx: int) -> None:
+        """Set the sync status for a specific video view.
+
+        Parameters
+        ----------
+        status : SyncStatus
+            The synchronization status to set.
+        media_idx : int
+            Index of the video view to update.
+        """
+        self._video_views[media_idx].set_sync_status(status)
+
     @Slot()
-    def play_video(self) -> None:
+    def _play_video(self) -> None:
         """Play the selected video with its original frame rate."""
         if self._is_playing:
             logger.warning(
@@ -287,7 +300,7 @@ class VideoBrowser(SyncableMediaBrowser):
         self._play_timer.start()
 
     @Slot()
-    def pause_video(self) -> None:
+    def _pause_video(self) -> None:
         """Pause video playing and stop at current frame."""
         if not self._is_playing:
             logger.warning(
@@ -303,25 +316,12 @@ class VideoBrowser(SyncableMediaBrowser):
         self._frame_rate_tracker.reset()
 
     @Slot()
-    def toggle_play_pause(self) -> None:
+    def _toggle_play_pause(self) -> None:
         """Either play or pause the video based on the current state."""
         if self._is_playing:
-            self.pause_video()
+            self._pause_video()
         else:
-            self.play_video()
-
-    # Overrides the empty implementation of parent class
-    def set_sync_status(self, status: SyncStatus, media_idx: int) -> None:
-        """Set the sync status for a specific video view.
-
-        Parameters
-        ----------
-        status : SyncStatus
-            The synchronization status to set.
-        media_idx : int
-            Index of the video view to update.
-        """
-        self._video_views[media_idx].set_sync_status(status)
+            self._play_video()
 
     @Slot()
     def _play_next_frame(self) -> None:
@@ -331,7 +331,7 @@ class VideoBrowser(SyncableMediaBrowser):
             self._update_frame_rate()
         else:
             # Pause the video if we are in the end
-            self.pause_video()
+            self._pause_video()
 
     def _update_frame_rate(self) -> None:
         """Update frame rate state and possibly also displayed fps."""

--- a/src/videomeg_browser/video_browser.py
+++ b/src/videomeg_browser/video_browser.py
@@ -323,6 +323,7 @@ class VideoBrowser(SyncableMediaBrowser):
                 "Received signal to pause video even though video should not "
                 "be playing. Skipping action."
             )
+            return
         logger.debug("Pausing video.")
         self._is_playing = False
         self._play_timer.stop()

--- a/src/videomeg_browser/video_browser.py
+++ b/src/videomeg_browser/video_browser.py
@@ -284,7 +284,6 @@ class VideoBrowser(SyncableMediaBrowser):
         """
         self._video_views[media_idx].set_sync_status(status)
 
-    @Slot()
     def _play_video(self) -> None:
         """Play the selected video with its original frame rate."""
         if self._is_playing:
@@ -299,7 +298,6 @@ class VideoBrowser(SyncableMediaBrowser):
         # Start the timer that controls automatic frame updates
         self._play_timer.start()
 
-    @Slot()
     def _pause_video(self) -> None:
         """Pause video playing and stop at current frame."""
         if not self._is_playing:


### PR DESCRIPTION
Fixed the problem by pausing all other media browsers when one media browser starts playback.