### PR TITLE
Correct decreasing timestamps due to regresson inaccuracy

### DIFF
--- a/scripts/run_hyperscanning_demo.py
+++ b/scripts/run_hyperscanning_demo.py
@@ -70,11 +70,6 @@ def main() -> None:
     audio_timestamps_ms = audio.get_audio_timestamps_ms()
     raw_timestamps_ms = get_raw_timestamps(raw, RAW_TIMING_CHANNEL)
 
-    # For some reason there are two audio timestamps that are smaller than the previous
-    # one. Sort the timestamps to make them non-decreasing and avoid error in aligner
-    # creation.
-    audio_timestamps_ms.sort()
-
     # Use the timestamps to create aligners for videos and audio to sync them with
     # the MEG data.
     vid_aligner1 = TimestampAligner(

--- a/src/videomeg_browser/media/audio.py
+++ b/src/videomeg_browser/media/audio.py
@@ -309,6 +309,10 @@ class AudioFileHelsinkiVideoMEG(AudioFile):
                 self.buffer_timestamps_ms[i] = ts
         # close the file
 
+        # Make sure that the timestamps are increasing
+        if not np.all(np.diff(self.buffer_timestamps_ms) >= 0):
+            raise ValueError("Audio buffer timestamps are not non-decreasing.")
+
         # Calculate stats for a single sample.
         self._bit_depth = self._get_bit_depth(self.format_string)
         self._n_bytes_per_sample = struct.calcsize(self.format_string)

--- a/src/videomeg_browser/media/audio.py
+++ b/src/videomeg_browser/media/audio.py
@@ -592,4 +592,13 @@ class AudioFileHelsinkiVideoMEG(AudioFile):
             regression_errors.max(),
         )
 
+        # Make sure that the timestamps are non-decreasing.
+        timestamps_diff = np.diff(audio_timestamps_ms)
+        if not np.all(timestamps_diff >= 0):
+            logger.warning(
+                f"Piecewise linear regression produced {np.sum(timestamps_diff < 0)} "
+                "decreasing timestamps. Making timestamps non-decreasing."
+            )
+            audio_timestamps_ms = np.maximum.accumulate(audio_timestamps_ms)
+
         self._audio_timestamps_ms = audio_timestamps_ms


### PR DESCRIPTION
Audio timestamps for all samples are computed with piecewise linear regression. At the boundaries of the regression segments, there was occasionally one decreasing timestamp. I fixed this by simply replacing the decreasing timestamp with the value of the previous timestamp. Also did refactoring.